### PR TITLE
[slack regex fix] Improve performance and don't require space after handle

### DIFF
--- a/lib/foodtruck_bot/slack.ex
+++ b/lib/foodtruck_bot/slack.ex
@@ -12,7 +12,7 @@ defmodule FoodtruckBot.Slack do
   def handle_event(_, _, state), do: {:ok, state}
 
   defp parse_message(message, slack) do
-    if Regex.run(~r/<@#{slack.me.id}>:?\s+.*today.*/, message.text) do
+    if Regex.run(~r/<@#{slack.me.id}>:?.*?\btoday\b/, message.text) do
       send_message("Checking today's trucks...", message.channel, slack)
       Task.start(fn -> FoodtruckBot.Twitter.fetch_trucks(message, slack) end)
     end


### PR DESCRIPTION
- Look for 'today' in word boundaries instead of sandwiched between
greedy .* matchers
- Do not require a space after the foodtrucks handle in the Slack
message